### PR TITLE
Fix Sanity data-fetching and cache revalidation for Next.js 16

### DIFF
--- a/apps/frontend/src/app/[slug]/page.tsx
+++ b/apps/frontend/src/app/[slug]/page.tsx
@@ -132,6 +132,6 @@ export async function generateStaticParams() {
 	});
 
 	return posts
-		.map((post) => ({ params: { slug: post.slug?.current } }))
-		.filter(({ params }) => Boolean(params.slug));
+		.map((post) => ({ slug: post.slug?.current }))
+		.filter((params) => Boolean(params.slug));
 }

--- a/apps/frontend/src/app/api/feed/[format]/route.ts
+++ b/apps/frontend/src/app/api/feed/[format]/route.ts
@@ -21,6 +21,7 @@ export async function GET(
 
 	const posts = await fetch(feedQuery, {
 		tags: ['post'],
+		draftMode: false,
 	});
 
 	const f = new Feed({

--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -1,5 +1,5 @@
 import { parseBody } from 'next-sanity/webhook';
-import { updateTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { type NextRequest, NextResponse } from 'next/server';
 
 type WebhookPayload = {
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
 			return new Response(JSON.stringify({ message, body }), { status: 400 });
 		}
 
-		updateTag(body._type);
+		revalidateTag(body._type, { expire: 0 });
 
 		return NextResponse.json({ body });
 	} catch (error) {

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata(): Promise<Metadata> {
 		}
 	`);
 	const settings = await fetch(homeMetadataQuery, {
-		tags: ['post'],
+		tags: ['settings'],
 		stega: false,
 	});
 

--- a/apps/frontend/src/utils/sanity-fetch.ts
+++ b/apps/frontend/src/utils/sanity-fetch.ts
@@ -19,7 +19,7 @@ export async function fetch<R = Any, const G extends string = string>(
 			: (await nextDraftMode()).isEnabled;
 
 	const perspective = isEnabled ? 'drafts' : 'published';
-	const stega = options?.stega || isEnabled;
+	const stega = options?.stega ?? isEnabled;
 
 	return client.fetch(query, params, { perspective, stega, next: { tags } });
 }


### PR DESCRIPTION
## Summary
- Use `revalidateTag` instead of `updateTag` in the webhook route handler, since `updateTag` is restricted to Server Actions in Next.js 16
- Fix wrong cache tag on homepage metadata query (`'post'` → `'settings'`)
- Fix `generateStaticParams` return shape to match app router API
- Use nullish coalescing for stega option so explicit `stega: false` is respected in draft mode
- Add `draftMode: false` to feed route to prevent draft content leaking into RSS/Atom feeds

## Test plan
- [x] Verify webhook revalidation works when publishing changes in Sanity
- [x] Verify draft mode with visual editing still works correctly
- [x] Verify metadata doesn't contain stega-encoded strings in draft mode
- [x] Verify RSS/Atom feed serves only published content